### PR TITLE
Stupid cache, refresh and new feature Station

### DIFF
--- a/data/build.gradle
+++ b/data/build.gradle
@@ -33,6 +33,11 @@ tasks.whenTaskAdded { task ->
     }
 }
 
+task licenseFormatForKotlin(type: com.hierynomus.gradle.license.tasks.LicenseFormat) {
+    source = fileTree(dir: "src/main/java").include("**/*.kt")
+}
+licenseFormat.dependsOn licenseFormatForKotlin
+
 license {
     header rootProject.file('mit.header')
     strictCheck true

--- a/data/src/main/java/se/geecity/android/data/AppExecutors.kt
+++ b/data/src/main/java/se/geecity/android/data/AppExecutors.kt
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package se.geecity.android.data
 
 import android.os.Handler

--- a/data/src/main/java/se/geecity/android/data/clients/SelfServiceBicycleServiceProvider.kt
+++ b/data/src/main/java/se/geecity/android/data/clients/SelfServiceBicycleServiceProvider.kt
@@ -70,7 +70,7 @@ class SelfServiceBicycleServiceProvider(apiKey: String, private val appExecutors
                 .create()
     }
 
-    override fun getStationObjects(): Resource<List<StationObject>> {
+    override fun getStationObjects(immediate: Boolean): Resource<List<StationObject>> {
         val request = Request.Builder().url(url).build()
 
         try {

--- a/data/src/main/java/se/geecity/android/data/model/ParcelableStationObject.kt
+++ b/data/src/main/java/se/geecity/android/data/model/ParcelableStationObject.kt
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package se.geecity.android.data.model
 
 import android.os.Parcelable

--- a/data/src/main/java/se/geecity/android/data/model/StationObjectDao.kt
+++ b/data/src/main/java/se/geecity/android/data/model/StationObjectDao.kt
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package se.geecity.android.data.model
 
 import com.google.gson.annotations.SerializedName

--- a/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
+++ b/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
@@ -34,13 +34,13 @@ class CachedStationObjectRepository(private val networkRepository: SelfServiceBi
     private var cache: Resource<List<StationObject>>? = null
     private var lastRequestTime: Long = 0
 
-    override fun getStationObjects(): Resource<List<StationObject>> {
+    override fun getStationObjects(immediate: Boolean): Resource<List<StationObject>> {
 
         val now = SystemClock.elapsedRealtime()
         val cache = cache
 
-        val resource = if (now - lastRequestTime < 30000 && cache != null) {
-            cache
+        val resource = if (shouldReturnCache(now, immediate)) {
+            cache!!
         } else {
             networkRepository.getStationObjects().also { this.cache = it }
         }
@@ -48,4 +48,6 @@ class CachedStationObjectRepository(private val networkRepository: SelfServiceBi
         lastRequestTime = now
         return resource
     }
+
+    private fun shouldReturnCache(now: Long, immediate: Boolean) = now - lastRequestTime < 30000 && cache != null && !immediate
 }

--- a/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
+++ b/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package se.geecity.android.data.repository
 
 import android.os.SystemClock

--- a/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
+++ b/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
@@ -49,5 +49,9 @@ class CachedStationObjectRepository(private val networkRepository: SelfServiceBi
         return resource
     }
 
+    override fun getStationObject(id: Int): Resource<StationObject> {
+        return networkRepository.getStationObject(id)
+    }
+
     private fun shouldReturnCache(now: Long, immediate: Boolean) = now - lastRequestTime < 30000 && cache != null && !immediate
 }

--- a/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
+++ b/data/src/main/java/se/geecity/android/data/repository/CachedStationObjectRepository.kt
@@ -1,0 +1,28 @@
+package se.geecity.android.data.repository
+
+import android.os.SystemClock
+import se.geecity.android.data.clients.SelfServiceBicycleServiceProvider
+import se.geecity.android.domain.entities.Resource
+import se.geecity.android.domain.entities.StationObject
+import se.geecity.android.domain.repositories.StationObjectRepository
+
+class CachedStationObjectRepository(private val networkRepository: SelfServiceBicycleServiceProvider) : StationObjectRepository {
+
+    private var cache: Resource<List<StationObject>>? = null
+    private var lastRequestTime: Long = 0
+
+    override fun getStationObjects(): Resource<List<StationObject>> {
+
+        val now = SystemClock.elapsedRealtime()
+        val cache = cache
+
+        val resource = if (now - lastRequestTime < 30000 && cache != null) {
+            cache
+        } else {
+            networkRepository.getStationObjects().also { this.cache = it }
+        }
+
+        lastRequestTime = now
+        return resource
+    }
+}

--- a/domain/src/main/java/se/geecity/android/domain/nearby/GetStationsObjects.kt
+++ b/domain/src/main/java/se/geecity/android/domain/nearby/GetStationsObjects.kt
@@ -32,4 +32,8 @@ class GetStationsObjects(private val stationObjectRepository: StationObjectRepos
     operator fun invoke(): Resource<List<StationObject>> {
         return stationObjectRepository.getStationObjects()
     }
+
+    fun immediate(): Resource<List<StationObject>> {
+        return stationObjectRepository.getStationObjects(immediate = true)
+    }
 }

--- a/domain/src/main/java/se/geecity/android/domain/repositories/StationObjectRepository.kt
+++ b/domain/src/main/java/se/geecity/android/domain/repositories/StationObjectRepository.kt
@@ -28,5 +28,5 @@ import se.geecity.android.domain.entities.StationObject
 
 interface StationObjectRepository {
 
-    fun getStationObjects(): Resource<List<StationObject>>
+    fun getStationObjects(immediate: Boolean = false): Resource<List<StationObject>>
 }

--- a/domain/src/main/java/se/geecity/android/domain/repositories/StationObjectRepository.kt
+++ b/domain/src/main/java/se/geecity/android/domain/repositories/StationObjectRepository.kt
@@ -29,4 +29,5 @@ import se.geecity.android.domain.entities.StationObject
 interface StationObjectRepository {
 
     fun getStationObjects(immediate: Boolean = false): Resource<List<StationObject>>
+    fun getStationObject(id: Int): Resource<StationObject>
 }

--- a/domain/src/main/java/se/geecity/android/domain/station/GetStationObject.kt
+++ b/domain/src/main/java/se/geecity/android/domain/station/GetStationObject.kt
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package se.geecity.android.domain.station
+
+import se.geecity.android.domain.entities.Resource
+import se.geecity.android.domain.entities.StationObject
+import se.geecity.android.domain.repositories.StationObjectRepository
+
+class GetStationObject(private val stationObjectRepository: StationObjectRepository) {
+
+    operator fun invoke(id: Int): Resource<StationObject> {
+        return stationObjectRepository.getStationObject(id)
+    }
+}

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/SteerAndPutApplication.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/SteerAndPutApplication.kt
@@ -45,7 +45,7 @@ class SteerAndPutApplication : Application() {
         startKoin {
             androidLogger()
             androidContext(this@SteerAndPutApplication)
-            modules(mainModule, commonModule, stationModule, nearbyModule, mapModule, favoriteModule)
+            modules(mainModule, commonModule, stationModule, nearbyModule, mapModule, favoriteModule, se.geecity.android.steerandput.station.di.stationModule)
         }
     }
 

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/common/adapter/StationInteractionListener.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/common/adapter/StationInteractionListener.kt
@@ -29,6 +29,7 @@ import se.geecity.android.steerandput.common.logging.FirebaseLoggerV2
 import se.geecity.android.steerandput.common.persistance.FavoriteUtil
 import se.geecity.android.steerandput.common.view.ViewIdentifier
 import se.geecity.android.steerandput.mapv2.MapFragment
+import se.geecity.android.steerandput.station.StationFragment
 
 interface StationInteractionListener {
     fun onStationClicked(station: StationObject)
@@ -49,7 +50,8 @@ class StationInteractionListenerImpl(
 
     override fun onContextMenuDetailsClicked(station: StationObject) {
         firebaseLogger.stationListItemDetailsClicked(station)
-        //TODO (widar): Navigate to station view. (STILL RELEVANT?)
+        val request = NavigationManager.NavigationRequest(ViewIdentifier.STATION, StationFragment.createArguments(station))
+        NavigationManager.instance?.navigate(request)
     }
 
     override fun onContextMenuFavoriteToggled(station: StationObject) {

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
@@ -57,7 +57,7 @@ val commonModule = module {
     single { FirebaseLoggerV2(get(), androidContext()) }
     single { AppExecutors() }
 
-    factory<StationObjectsGetter> { StationObjectsGetterImpl(get(), get()) }
+    factory<StationObjectsGetter> { StationObjectsGetterImpl(get(), get(), get()) }
 
     factory { SelfServiceBicycleServiceProvider(get(named(BICYCLESERVICE_API_KEY_PROPERTY)), get()) }
     single<StationObjectRepository> { CachedStationObjectRepository(get()) }

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
@@ -59,7 +59,7 @@ val commonModule = module {
 
     factory<StationObjectsGetter> { StationObjectsGetterImpl(get(), get(), get()) }
 
-    factory { SelfServiceBicycleServiceProvider(get(named(BICYCLESERVICE_API_KEY_PROPERTY)), get()) }
+    factory { SelfServiceBicycleServiceProvider(get(named(BICYCLESERVICE_API_KEY_PROPERTY))) }
     single<StationObjectRepository> { CachedStationObjectRepository(get()) }
 
     factory { GetStationsObjects(get()) }

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/common/di/CommonModule.kt
@@ -27,11 +27,17 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.firebase.analytics.FirebaseAnalytics
 import org.koin.android.ext.koin.androidContext
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import se.geecity.android.data.AppExecutors
+import se.geecity.android.data.clients.SelfServiceBicycleServiceProvider
+import se.geecity.android.data.repository.CachedStationObjectRepository
+import se.geecity.android.domain.nearby.GetStationsObjects
+import se.geecity.android.domain.repositories.StationObjectRepository
 import se.geecity.android.steerandput.common.adapter.StationAdapterV2
 import se.geecity.android.steerandput.common.adapter.StationInteractionListener
 import se.geecity.android.steerandput.common.adapter.StationInteractionListenerImpl
+import se.geecity.android.steerandput.common.constants.BICYCLESERVICE_API_KEY_PROPERTY
 import se.geecity.android.steerandput.common.logging.FirebaseLogger
 import se.geecity.android.steerandput.common.logging.FirebaseLoggerV2
 import se.geecity.android.steerandput.common.persistance.FavoriteUtil
@@ -52,4 +58,11 @@ val commonModule = module {
     single { AppExecutors() }
 
     factory<StationObjectsGetter> { StationObjectsGetterImpl(get(), get()) }
+
+    factory { SelfServiceBicycleServiceProvider(get(named(BICYCLESERVICE_API_KEY_PROPERTY)), get()) }
+    single<StationObjectRepository> { CachedStationObjectRepository(get()) }
+
+    factory { GetStationsObjects(get()) }
+
+
 }

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/common/view/Util.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/common/view/Util.kt
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package se.geecity.android.steerandput.common.view
+
+import android.view.View
+
+fun View.gone() {
+    this.visibility = View.GONE
+}
+
+fun View.visible() {
+    this.visibility = View.VISIBLE
+}

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/main/MainPresenter.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/main/MainPresenter.kt
@@ -29,7 +29,8 @@ import se.geecity.android.steerandput.main.interactor.StationsInteractor
 /**
  * Presenter for the main view of the app.
  */
-class MainPresenter(val stationsInteractor: StationsInteractor) {
+class MainPresenter(val stationsInteractor: StationsInteractor,
+                    private val mainComm: MainComm) {
 
     lateinit var mainView: MainView
 
@@ -45,6 +46,7 @@ class MainPresenter(val stationsInteractor: StationsInteractor) {
 
     fun refreshPressed() {
         stationsInteractor.getStations(stationsCallback)
+        mainComm.requestRefresh()
     }
 
     fun viewActiveFromBackstack(viewIdentifier: ViewIdentifier) {

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/nearby/di/NearbyModule.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/nearby/di/NearbyModule.kt
@@ -24,18 +24,9 @@
 package se.geecity.android.steerandput.nearby.di
 
 import org.koin.android.viewmodel.dsl.viewModel
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import se.geecity.android.data.clients.SelfServiceBicycleServiceProvider
-import se.geecity.android.domain.nearby.GetStationsObjects
-import se.geecity.android.domain.repositories.StationObjectRepository
-import se.geecity.android.steerandput.common.constants.BICYCLESERVICE_API_KEY_PROPERTY
 import se.geecity.android.steerandput.nearby.NearbyViewModel
 
 val nearbyModule = module {
-
-    factory<StationObjectRepository> { SelfServiceBicycleServiceProvider(get(named(BICYCLESERVICE_API_KEY_PROPERTY)), get()) }
-    factory { GetStationsObjects(get()) }
-
     viewModel { NearbyViewModel(get(), get()) }
 }

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationFragment.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationFragment.kt
@@ -38,6 +38,7 @@ import org.koin.android.ext.android.inject
 import org.koin.android.viewmodel.ext.android.viewModel
 import se.geecity.android.data.model.ParcelableStationObject
 import se.geecity.android.data.model.toParcelable
+import se.geecity.android.domain.entities.Failure
 import se.geecity.android.domain.entities.Resource
 import se.geecity.android.domain.entities.StationObject
 import se.geecity.android.domain.entities.Success
@@ -92,6 +93,10 @@ class StationFragment : StationShowingFragment() {
 
         setStationInfo(station)
 
+        swipeRefreshLayout.setOnRefreshListener {
+            stationViewModel.fetchStationObject()
+        }
+
         firebaseLogger.pageView(ViewIdentifier.STATION, station)
     }
 
@@ -105,8 +110,14 @@ class StationFragment : StationShowingFragment() {
         stationViewModel.stationObjectId = station.id
         stationViewModel.stationObject.observe(this) { stationResource ->
             when (stationResource) {
-                Resource.Loading -> stationName.text = "LOADING"
-                is Success -> setStationInfo(stationResource.body)
+                Resource.Loading -> swipeRefreshLayout.isRefreshing = true
+                is Success -> {
+                    setStationInfo(stationResource.body)
+                    swipeRefreshLayout.isRefreshing = false
+                }
+                is Failure -> {
+                    swipeRefreshLayout.isRefreshing = false
+                }
             }
         }
     }

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationFragment.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationFragment.kt
@@ -1,0 +1,149 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package se.geecity.android.steerandput.station
+
+import android.location.Location
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.observe
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
+import kotlinx.android.synthetic.main.fragment_station.*
+import org.koin.android.ext.android.inject
+import org.koin.android.viewmodel.ext.android.viewModel
+import se.geecity.android.data.model.ParcelableStationObject
+import se.geecity.android.data.model.toParcelable
+import se.geecity.android.domain.entities.Resource
+import se.geecity.android.domain.entities.StationObject
+import se.geecity.android.domain.entities.Success
+import se.geecity.android.steerandput.R
+import se.geecity.android.steerandput.common.adapter.StationInteractionListener
+import se.geecity.android.steerandput.common.logging.FirebaseLoggerV2
+import se.geecity.android.steerandput.common.model.Station
+import se.geecity.android.steerandput.common.util.getDistanceBetweenAsString
+import se.geecity.android.steerandput.common.util.hasCoarseLocationPermission
+import se.geecity.android.steerandput.common.util.hasFineLocationPermission
+import se.geecity.android.steerandput.common.view.StationShowingFragment
+import se.geecity.android.steerandput.common.view.ViewIdentifier
+import se.geecity.android.steerandput.common.view.gone
+
+//TODO remove the inheritence to station showing
+class StationFragment : StationShowingFragment() {
+    override var stations: List<Station> = listOf()
+
+    private val station: StationObject by lazy { station() }
+    private val stationViewModel: StationViewModel by viewModel()
+
+    private val firebaseLogger: FirebaseLoggerV2 by inject()
+    private val stationInteractionListener: StationInteractionListener by inject()
+
+    companion object {
+        private val EXTRA_STATION = "station"
+
+        fun createArguments(station: StationObject): Bundle {
+            return Bundle().apply { putParcelable(EXTRA_STATION, station.toParcelable()) }
+        }
+
+        private fun StationFragment.station(): StationObject {
+            val station = arguments?.getParcelable<ParcelableStationObject>(EXTRA_STATION)?.toDomainObject()
+            if (station != null) {
+                return station
+            }
+            throw IllegalStateException("No station argument for StationFragment")
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_station, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        mapView.onCreate(savedInstanceState)
+
+        setupMap()
+        chart.gone()
+        chartTitle.gone()
+
+        setStationInfo(station)
+
+        firebaseLogger.pageView(ViewIdentifier.STATION, station)
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        stationViewModel.location.observe(this) {
+            setLocationText(it)
+        }
+
+        stationViewModel.stationObjectId = station.id
+        stationViewModel.stationObject.observe(this) { stationResource ->
+            when (stationResource) {
+                Resource.Loading -> stationName.text = "LOADING"
+                is Success -> setStationInfo(stationResource.body)
+            }
+        }
+    }
+
+    private fun setStationInfo(station: StationObject) {
+        stationName.text = station.name
+        stationBikeText.text = station.availableBikes.toString()
+        stationStandsText.text = station.availableBikeStands.toString()
+    }
+
+    private fun setLocationText(location: Location) {
+        stationDistance.text = getDistanceBetweenAsString(station, location)
+    }
+
+    private fun setupMap() {
+        mapView.getMapAsync { map ->
+            if (hasFineLocationPermission(activity!!) || hasCoarseLocationPermission(activity!!)) {
+                map.isMyLocationEnabled = true
+            }
+
+            val pos = LatLng(station.lat, station.longitude)
+            val cp = CameraPosition.Builder()
+                    .target(pos)
+                    .zoom(15.5f)
+                    .build()
+            val update = CameraUpdateFactory.newCameraPosition(cp)
+            map.moveCamera(update)
+
+            map.uiSettings.isMapToolbarEnabled = false
+
+            val markerOptions = MarkerOptions().position(pos)
+            map.addMarker(markerOptions)
+
+            map.setOnMapClickListener {
+                stationInteractionListener.onStationClicked(station)
+                firebaseLogger.mapClicked(station)
+            }
+        }
+    }
+}

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationViewModel.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationViewModel.kt
@@ -1,0 +1,78 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package se.geecity.android.steerandput.station
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.android.gms.location.FusedLocationProviderClient
+import se.geecity.android.data.AppExecutors
+import se.geecity.android.domain.entities.Failure
+import se.geecity.android.domain.entities.Resource
+import se.geecity.android.domain.entities.StationObject
+import se.geecity.android.domain.station.GetStationObject
+import se.geecity.android.steerandput.common.location.LocationLiveData
+import se.geecity.android.steerandput.main.MainComm
+
+class StationViewModel(private val getStationsObject: GetStationObject,
+                       private val appExecutors: AppExecutors,
+                       private val mainComm: MainComm,
+                       fusedLocationProviderClient: FusedLocationProviderClient) : ViewModel() {
+
+    var stationObjectId: Int? = null
+
+    val location = LocationLiveData(fusedLocationProviderClient)
+
+    val stationObject: MutableLiveData<Resource<StationObject>> by lazy {
+        MutableLiveData<Resource<StationObject>>().also {
+            it.value = Resource.Loading
+
+            val stationObjectId = stationObjectId
+            if (stationObjectId != null) {
+                appExecutors.worker.execute {
+                    val station = getStationsObject(stationObjectId)
+                    it.postValue(station)
+                }
+            } else {
+                it.postValue(Failure("No station object ID present on getting station object"))
+            }
+        }
+    }
+
+    fun fetchStationObject() {
+        stationObject.value = Resource.Loading
+        makeStationObjectFetch()
+    }
+
+    private fun makeStationObjectFetch() {
+        val stationObjectId = stationObjectId
+        if (stationObjectId != null) {
+            appExecutors.worker.execute {
+                val station = getStationsObject(stationObjectId)
+                stationObject.postValue(station)
+            }
+        } else {
+            stationObject.postValue(Failure("No station object ID present on getting station object"))
+        }
+    }
+}

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationViewModel.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/station/StationViewModel.kt
@@ -39,6 +39,16 @@ class StationViewModel(private val getStationsObject: GetStationObject,
                        private val mainComm: MainComm,
                        fusedLocationProviderClient: FusedLocationProviderClient) : ViewModel() {
 
+    init {
+        mainComm.addObserver(object : MainComm.MainObserver {
+            override fun refreshRequested() {
+                stationObject.value = Resource.Loading
+                fetchStationObject()
+            }
+
+        })
+    }
+
     var stationObjectId: Int? = null
 
     val location = LocationLiveData(fusedLocationProviderClient)

--- a/steerAndPut/src/main/java/se/geecity/android/steerandput/station/di/StationModule.kt
+++ b/steerAndPut/src/main/java/se/geecity/android/steerandput/station/di/StationModule.kt
@@ -1,0 +1,35 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Alexander Widar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package se.geecity.android.steerandput.station.di
+
+import org.koin.android.viewmodel.dsl.viewModel
+import org.koin.dsl.module
+import se.geecity.android.domain.station.GetStationObject
+import se.geecity.android.steerandput.station.StationViewModel
+
+val stationModule = module {
+    viewModel { StationViewModel(get(), get(), get(), get()) }
+
+    factory { GetStationObject(get()) }
+}

--- a/steerAndPut/src/main/res/layout/fragment_station.xml
+++ b/steerAndPut/src/main/res/layout/fragment_station.xml
@@ -102,6 +102,7 @@
         map:liteMode="true"/>
 
     <TextView
+        android:id="@+id/chartTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"

--- a/steerAndPut/src/main/res/layout/fragment_station.xml
+++ b/steerAndPut/src/main/res/layout/fragment_station.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 
     MIT License
 
@@ -24,97 +23,101 @@
     SOFTWARE.
 
 -->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="match_parent"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipeRefreshLayout"
     android:layout_width="match_parent"
-    >
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/stationName"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="24dp"
-        android:text="Station Name"
-        android:textAppearance="@style/Headline"/>
-
-    <TextView
-        android:id="@+id/stationDistance"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/stationName"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="12dp"
-        android:text="0 km" />
-
-    <LinearLayout
-        android:id="@+id/station_bikes_stand_container"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="8dp"
-        android:gravity="center_vertical"
-        android:orientation="horizontal" >
-
-        <ImageView
-            android:id="@+id/station_item_bikes_img"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:src="@drawable/ic_launcher"
-            tools:ignore="ContentDescription" />
-
-        <TextView
-            android:id="@+id/stationBikeText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:text="0"
-            android:textSize="52sp" />
-
-        <ImageView
-            android:id="@+id/station_item_stand_img"
-            android:layout_width="64dp"
-            android:layout_height="64dp"
-            android:layout_marginLeft="24dp"
-            android:src="@drawable/p_icon"
-            tools:ignore="ContentDescription" />
-
-        <TextView
-            android:id="@+id/stationStandsText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:text="0"
-            android:textSize="52sp" />
-    </LinearLayout>
-
-    <com.google.android.gms.maps.MapView
-        xmlns:map="http://schemas.android.com/apk/res-auto"
+    <ScrollView xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="196dp"
-        android:layout_marginTop="24dp"
-        android:id="@+id/mapView"
-        map:liteMode="true"/>
+        android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/chartTitle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="16dp"
-        android:textAppearance="?android:textAppearanceMedium"
-        android:text="@string/station_chart_title"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-    <com.github.mikephil.charting.charts.LineChart
-        android:id="@+id/chart"
-        android:layout_width="match_parent"
-        android:layout_height="244dp"
-        android:layout_marginTop="8dp"/>
-    
-</LinearLayout>
-</ScrollView>
+            <LinearLayout
+                android:id="@+id/station_bikes_stand_container"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:id="@+id/station_item_bikes_img"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:src="@drawable/ic_launcher"
+                    tools:ignore="ContentDescription" />
+
+                <ImageView
+                    android:id="@+id/station_item_stand_img"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:layout_marginLeft="24dp"
+                    android:src="@drawable/p_icon"
+                    tools:ignore="ContentDescription" />
+
+                <TextView
+                    android:id="@+id/stationBikeText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:text="0"
+                    android:textSize="52sp" />
+
+                <TextView
+                    android:id="@+id/stationStandsText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:text="0"
+                    android:textSize="52sp" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/stationDistance"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/stationName"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="12dp"
+                android:text="0 km" />
+
+            <TextView
+                android:id="@+id/stationName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="24dp"
+                android:text="Station Name"
+                android:textAppearance="@style/Headline" />
+
+            <TextView
+                android:id="@+id/chartTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="16dp"
+                android:text="@string/station_chart_title"
+                android:textAppearance="?android:textAppearanceMedium" />
+
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/chart"
+                android:layout_width="match_parent"
+                android:layout_height="244dp"
+                android:layout_marginTop="8dp" />
+
+            <com.google.android.gms.maps.MapView xmlns:map="http://schemas.android.com/apk/res-auto"
+                android:id="@+id/mapView"
+                android:layout_width="match_parent"
+                android:layout_height="196dp"
+                android:layout_marginTop="24dp"
+                map:liteMode="true" />
+
+        </LinearLayout>
+    </ScrollView>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
- Added a naive in-memory cache so switching between tabs won't have to cause a loading delay due to new data being fetched.
- Immediacy in the repository for discerning whether a cached response is good enough.
- Injected communication object from the main feature. Mainly used for the refresh button, maybe something else in the future
- New Feature: Station. Detail page for single station, sadly very boring because there is no historical data endpoint available atm

Caveats:
The cache is really dumb. For best effect I'd like for the repository to return a LiveData, because then the cache could return a cached reponse AND trigger a refresh and send the fresh data downstream after fetching. The problem is that then the domain module would need to know about android framework and now it's only a plain java module